### PR TITLE
Update users display filter

### DIFF
--- a/src/sections/Users.tsx
+++ b/src/sections/Users.tsx
@@ -40,8 +40,9 @@ export const Users: React.FC = () => {
     },
     ...(accounts || []).filter(
       account =>
-        ![...AvailableIntegrations, 'settings'].includes(account.member) &&
-        account.member !== account.username
+        !AvailableIntegrations.includes(account.member) &&
+        account.member !== account.username &&
+        account.member.includes('@')
     ),
   ];
 


### PR DESCRIPTION
### Summary

Generalize the users display filter to remove any collaborators without a @ in their name, i.e. not email addresses.

We are considering changes in https://github.com/praetorian-inc/chaos/pull/814 and likely other future features where account objects will be used for storing metadata for the account. This change will ensure that such account objects are never displayed as authorized users in the Chariot UI.

### Type

Small refactor

