### PR TITLE
Small fixes for seed deletion

### DIFF
--- a/src/hooks/useSeeds.ts
+++ b/src/hooks/useSeeds.ts
@@ -171,7 +171,7 @@ export function useDeleteSeed() {
             ...previous,
             pages: previous.pages.map(page =>
               page.filter(
-                item => item.dns !== seed.dns && item.name !== seed.name
+                item => item.dns !== seed.dns || item.name !== seed.name
               )
             ),
           };

--- a/src/hooks/useSeeds.ts
+++ b/src/hooks/useSeeds.ts
@@ -148,19 +148,19 @@ export function useDeleteSeed() {
     }
   );
 
-  return useMutation<void, Error, { seed: string; showSnackbar?: boolean }>({
+  return useMutation<void, Error, { seed: Seed; showSnackbar?: boolean }>({
     defaultErrorMessage: `Failed to delete seed`,
     mutationFn: async ({ seed }) => {
       await axios.delete(`/seed`, {
         data: {
-          key: `#seed#${seed}`,
+          key: seed.key,
         },
       });
     },
     onSuccess: (_, { seed, showSnackbar = true }) => {
       showSnackbar &&
         Snackbar({
-          title: `Seed ${seed} removed`,
+          title: `Seed ${seed.name} removed`,
           description: '',
           variant: 'success',
         });
@@ -170,7 +170,9 @@ export function useDeleteSeed() {
           return {
             ...previous,
             pages: previous.pages.map(page =>
-              page.filter(item => item.dns !== seed)
+              page.filter(
+                item => item.dns !== seed.dns && item.name !== seed.name
+              )
             ),
           };
         }

--- a/src/sections/Seeds.tsx
+++ b/src/sections/Seeds.tsx
@@ -266,7 +266,7 @@ const Seeds: React.FC = () => {
             });
           } else {
             mutateAsync(
-              { seed: seed.dns, showSnackbar: !showBulk },
+              { seed: seed.key, showSnackbar: !showBulk },
               {
                 onSuccess: () => {
                   setSelectedRows([]);
@@ -375,7 +375,7 @@ const Seeds: React.FC = () => {
                   setIntegrationSeed(seeds[0]);
                 } else {
                   mutateAsync(
-                    { seed: seeds[0].dns },
+                    { seed: seeds[0].key},
                     {
                       onSuccess: () => {
                         setSelectedRows([]);

--- a/src/sections/Seeds.tsx
+++ b/src/sections/Seeds.tsx
@@ -266,7 +266,7 @@ const Seeds: React.FC = () => {
             });
           } else {
             mutateAsync(
-              { seed: seed.key, showSnackbar: !showBulk },
+              { seed: seed, showSnackbar: !showBulk },
               {
                 onSuccess: () => {
                   setSelectedRows([]);
@@ -375,7 +375,7 @@ const Seeds: React.FC = () => {
                   setIntegrationSeed(seeds[0]);
                 } else {
                   mutateAsync(
-                    { seed: seeds[0].key},
+                    { seed: seeds[0] },
                     {
                       onSuccess: () => {
                         setSelectedRows([]);


### PR DESCRIPTION
### Summary

Fixes a few small bugs with seed deletion:
 - Currently, only the DNS value is passed as the key when deleting. This will result in unexpected deletions when multiple seeds share the same DNS or DNS prefix. This PR passes the full key.
 - Shows the seed name in the snackbar, as that's more descriptive than DNS for integration seeds (and equivalent otherwise).
 - Ensures that the table update checks for both a matching DNS and name.

### Type

Bug Fix
