### PR TITLE
Azure Org-Level integration

### DIFF
--- a/src/utils/availableIntegrations.tsx
+++ b/src/utils/availableIntegrations.tsx
@@ -385,13 +385,6 @@ export const IntegrationsMeta: IntegrationMeta[] = [
         label: 'Tenant ID',
         value: '',
         placeholder: uuid,
-        name: 'tenant',
-        required: true,
-      },
-      {
-        label: 'Subscription ID',
-        value: '',
-        placeholder: uuid,
         name: 'value',
         required: true,
       },


### PR DESCRIPTION
### Summary

Adds support for Azure Org-Level integrations by removing the `subscription` specifier. The entire tenant will now be enumerated, so specifying the subscription is not necessary.

### Type

New Feature
