### PR TITLE
convert json to yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "config-ini-parser": "^1.6.1",
     "crypto-js": "^4.2.0",
     "date-fns": "^3.3.1",
+    "js-yaml": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -60,6 +61,7 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",
     "@types/crypto-js": "^4.2.2",
+    "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.5",
     "@types/node": "^20.11.23",
     "@types/react": "^18.2.61",

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -18,7 +18,7 @@ import { useGenericSearch } from '@/hooks/useGenericSearch';
 import { useOpenDrawer } from '@/sections/detailsDrawer/useOpenDrawer';
 import { useSearchContext } from '@/state/search';
 import { cn } from '@/utils/classname';
-import { getSeverityClass } from '@/utils/risk.util';
+import { getSeverityClass } from '@/utils/getSeverityClass.util';
 import { getRoute } from '@/utils/route.util';
 import { StorageKey } from '@/utils/storage/useStorage.util';
 import { useSearchParams } from '@/utils/url.util';

--- a/src/components/ui/RiskDropdown.tsx
+++ b/src/components/ui/RiskDropdown.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon } from '@heroicons/react/24/outline';
 
 import { useUpdateRisk } from '@/hooks/useRisks';
-import { getSeverityClass } from '@/utils/risk.util';
+import { getSeverityClass } from '@/utils/getSeverityClass.util';
 
 import {
   Risk,

--- a/src/sections/ProofOfExploit.tsx
+++ b/src/sections/ProofOfExploit.tsx
@@ -85,12 +85,12 @@ export function ProofOfExploit() {
         {proofOfExploit && (
           <>
             {riskComposite.includes('accepts-input') ? ( // assume https (port not provided)
-              <UniqueLinkList inputString={proofOfExploit} />
+              <UniqueLinkList inputString={proofOfExploit as string} />
             ) : (
               <Editor
                 height="100%"
                 language="yaml"
-                value={proofOfExploit}
+                value={proofOfExploit as string}
                 options={{
                   scrollBeyondLastLine: false,
                 }}

--- a/src/sections/detailsDrawer/RiskDrawer.tsx
+++ b/src/sections/detailsDrawer/RiskDrawer.tsx
@@ -25,7 +25,7 @@ import { useReRunJob } from '@/hooks/useJobs';
 import { useReportRisk, useUpdateRisk } from '@/hooks/useRisks';
 import { cn } from '@/utils/classname';
 import { formatDate } from '@/utils/date.util';
-import { getSeverityClass } from '@/utils/risk.util';
+import { getSeverityClass } from '@/utils/getSeverityClass.util';
 import { getRoute } from '@/utils/route.util';
 import { StorageKey } from '@/utils/storage/useStorage.util';
 import { generatePathWithSearch, useSearchParams } from '@/utils/url.util';

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,7 +261,7 @@ export type Secret = {
   matches: Match[];
 };
 
-type Match = {
+export type Match = {
   provenance: Provenance[];
   blob_metadata: BlobMetadata;
   blob_id: string;

--- a/src/utils/availableIntegrations.tsx
+++ b/src/utils/availableIntegrations.tsx
@@ -4,8 +4,8 @@ import { Input } from '@/components/form/Input';
 import { InputsT } from '@/components/form/Inputs';
 import AWSExample from '@/components/ui/AWSExample';
 import WebhookExample from '@/components/ui/WebhookExample';
-
 import { IntegrationType } from '@/types';
+
 import { getChariotWebhookURL } from './integration.util';
 
 export interface IntegrationMeta {

--- a/src/utils/getSeverityClass.util.ts
+++ b/src/utils/getSeverityClass.util.ts
@@ -1,0 +1,16 @@
+export const getSeverityClass = (key: string) => {
+  switch (key) {
+    case 'I':
+      return `border-gray-200`;
+    case 'L':
+      return `bg-indigo-100 border-indigo-200 text-indigo-800`;
+    case 'M':
+      return `bg-amber-100 border-amber-200 text-amber-800`;
+    case 'H':
+      return `bg-pink-100 border-pink-200 text-pink-800`;
+    case 'C':
+      return `bg-red-100 border-red-200 text-red-800`;
+    default:
+      return ``;
+  }
+};

--- a/src/utils/risk.util.ts
+++ b/src/utils/risk.util.ts
@@ -1,4 +1,4 @@
-import { Secret } from '../types';
+import yaml from 'js-yaml';
 
 interface NucleiTemplate {
   'curl-command': string;
@@ -11,9 +11,8 @@ interface NucleiTemplate {
 function isNucleiTemplate(file: unknown): file is Partial<NucleiTemplate> {
   return typeof file === 'object' && file !== null && 'template-id' in file;
 }
-// Function to check if the file object is a valid nuclei template and process it.
+
 function processNucleiTemplate(file: Partial<NucleiTemplate>): string {
-  // Helper function to create formatted sections.
   const formatSection = (
     title: string,
     content: string
@@ -41,92 +40,37 @@ ${content}`;
     .join('\n\n');
 }
 
-const getSeverityClass = (key: string) => {
-  switch (key) {
-    case 'I':
-      return `border-gray-200`;
-    case 'L':
-      return `bg-indigo-100 border-indigo-200 text-indigo-800`;
-    case 'M':
-      return `bg-amber-100 border-amber-200 text-amber-800`;
-    case 'H':
-      return `bg-pink-100 border-pink-200 text-pink-800`;
-    case 'C':
-      return `bg-red-100 border-red-200 text-red-800`;
-    default:
-      return ``;
-  }
-};
-
-const getDescription = (file: unknown) => {
+const getDescription = (file: unknown): string => {
   if (isNucleiTemplate(file)) {
     return processNucleiTemplate(file as Partial<NucleiTemplate>);
-  } else if (typeof file === 'object' && file !== null && 'matches' in file) {
-    const secret: Secret = file as Secret;
-    const output = secret.matches
-      .map(match => {
-        const secret = match.snippet.matching;
-        const provenanceInfo = match.provenance
-          .map(prov => {
-            return `Repository Path: ${prov.repo_path}
-    Blob Path: ${prov.blob_path}
-    First Commit:
-      - ID: ${prov.first_commit.commit_metadata.commit_id}
-      - Author: ${prov.first_commit.commit_metadata.author_name} (${prov.first_commit.commit_metadata.author_email})
-      - Message: ${prov.first_commit.commit_metadata.message.trim().split('\n')[0]}...`; // Using just the first line of the commit message for brevity
-          })
-          .join('\n');
-
-        const locationInfo = `Location:
-      - Blob ID: ${match.blob_id}
-      - Offset: ${match.location.offset_span.start} to ${match.location.offset_span.end}
-      - Source Code: Line ${match.location.source_span.start.line}, Column ${match.location.source_span.start.column} to Line ${match.location.source_span.end.line}, Column ${match.location.source_span.end.column}`;
-
-        const matchInfo = `Matching Snippet:
-      - Before: ${match.snippet.before.trim().split('\n').slice(-1)[0]}...
-      - Match: ${match.snippet.matching}
-      - After: ...${match.snippet.after.trim().split('\n')[0]}`;
-
-        const additionalInfo = `Rule:
-      - Name: ${match.rule_name}
-      - ID: ${match.rule_text_id}
-    Score: ${match.score || 'N/A'}
-    Comment: ${match.comment || 'None'}
-    Status: ${match.status || 'N/A'}`;
-
-        return `# ==================
-# SECRET
-# =======
-${secret}
-
+  } else if (typeof file === 'object' && file !== null) {
+    // Function to format the entire data with a header
+    const formatWithHeaders = (data: unknown, title: string): string => {
+      return `# ==================
+# ${title.toUpperCase()}
 # ==================
-# PROVENANCE
-# =======
-${provenanceInfo}
-    
-# ==================
-# LOCATION
-# =======
-${locationInfo}
-    
-# ==================
-# MATCH
-# =======
-${matchInfo}
-    
-# ==================
-# ADDITIONAL
-# =======
-${additionalInfo}
-`;
-      })
-      .join('\n');
-    return output;
+${yaml.dump(data, { noRefs: true, skipInvalid: true })}`;
+    };
+
+    // Function to iterate over keys and create sections if applicable
+    const createSections = (data: unknown): string => {
+      if (typeof data !== 'object' || data === null) {
+        return yaml.dump(data);
+      }
+
+      const entries = Object.entries(data as Record<string, unknown>);
+      const sections = entries.map(([key, value]) =>
+        formatWithHeaders(value, key)
+      );
+
+      return sections.join('\n');
+    };
+
+    // Create sections for the parsed file
+    return createSections(file);
   } else if (file !== undefined) {
     if (typeof file === 'object') {
-      const _replacer = null;
-      const numOfSpaces = 4;
-      return JSON.stringify(file, _replacer, numOfSpaces);
+      return yaml.dump(file, { noRefs: true, skipInvalid: true });
     } else {
       return file?.toString() || '';
     }
@@ -135,4 +79,4 @@ ${additionalInfo}
   return '';
 };
 
-export { getDescription, getSeverityClass };
+export { getDescription };


### PR DESCRIPTION
### Summary

The nosey parker data isn't always returned in the same format. I'm also structuring this data myself, which assumes I know all the data and what is most important, which is not true. I've restructured the logic for displaying secret-scanner results so that it just converts it from json into yaml and then displays some nice headers for easier scrolling.

This prevents issues with data not showing even if it is available in the response.

### Type

bug fix

### Context

This was caused by `blob_path` not being visible. This property is not always available, it's only sometimes available. I haven't looked into the logic as to why or why not some things may be available. Instead now we just default to show everything by automatically converting formats from json (not as readable) to yaml (more readable).
