### PR TITLE
Removes GitLab message from Add Seed menu

### DIFF
--- a/src/components/ui/AddSeeds.tsx
+++ b/src/components/ui/AddSeeds.tsx
@@ -78,9 +78,6 @@ export const AddSeeds: React.FC<Props> = (props: Props) => {
               <li>
                 GitHub Organizations: <code>https://github.com/acme-corp</code>
               </li>
-              <li>
-                Gitlab Organizations: <code>https://gitlab.com/acme-corp</code>
-              </li>
             </ul>
           </p>
           <p className="mt-1 text-sm text-gray-500">


### PR DESCRIPTION
### Summary
Removes the following message from the Add Seeds menu:
![image](https://github.com/praetorian-inc/chariot-ui/assets/87080623/3645e6db-5b86-41b1-87c5-6f15273ba326)

This is not possible. Chariot will only create GitLab jobs through the GitLab integration. And due to limitations in GitLab's API, adding this feature later probably isn't feasible (per Rad). 

### Type
Documentation Update
