### PR TITLE
Adds default collaborator label

### DIFF
--- a/src/sections/topNavBar/AccountDropdown.tsx
+++ b/src/sections/topNavBar/AccountDropdown.tsx
@@ -65,7 +65,7 @@ export const AccountDropdown: React.FC = () => {
             onClick: () => friend?.email && stopImpersonation(),
           },
           ...collaborators.map(collaborator => ({
-            label: collaborator.displayName,
+            label: collaborator.displayName || collaborator.email,
             icon: (
               <Avatar
                 account={String(collaborator.email)}


### PR DESCRIPTION
### Summary

If a user does not have a displayName, we should show the email in the top right nav

### Type

Bug fix

