### PR TITLE
Fix for outside click on Input Select

### DIFF
--- a/src/components/form/Select.tsx
+++ b/src/components/form/Select.tsx
@@ -192,7 +192,10 @@ const SelectItem = (props: SelectItemProps) => {
       key={value}
       aria-selected={isSelected}
       data-hovered={isHovered}
-      onClick={() => !disabled && handleSelect({ label, value })}
+      onMouseDown={event => {
+        event.stopPropagation();
+        !disabled && handleSelect({ label, value });
+      }}
       onMouseOver={() => !disabled && setHoverIndex(index)}
       ref={ref}
     >

--- a/src/components/form/Select.tsx
+++ b/src/components/form/Select.tsx
@@ -105,6 +105,7 @@ export const Select = (props: InputProps & SelectProps) => {
         aria-describedby={error ? `${name}-error` : name}
         onClick={() => setIsOpen(!isOpen)}
         onKeyUp={event => handleKeyEvent(event)}
+        onBlur={() => setIsOpen(false)}
         tabIndex={0}
         onChange={handleChange}
       />


### PR DESCRIPTION
### Summary

[Dashboard widget dropdown menu overlapping](https://github.com/praetorian-inc/chariot-ui/issues/148#top)

### Type

Bug fix

### Context


https://github.com/praetorian-inc/chariot-ui/assets/19853007/4922d7a1-8820-4780-8435-426651771172


