### PR TITLE
Moves intelligence tab under account menu; Rename label

### DIFF
--- a/src/sections/topNavBar/AccountDropdown.tsx
+++ b/src/sections/topNavBar/AccountDropdown.tsx
@@ -13,6 +13,7 @@ import { useMy } from '@/hooks/useMy';
 import Avatar from '@/sections/topNavBar/Avatar';
 import { useAuth } from '@/state/auth';
 import { getRoute } from '@/utils/route.util';
+import { ChartBarSquareIcon } from '@heroicons/react/24/outline';
 
 export const AccountDropdown: React.FC = () => {
   const { friend, me, startImpersonation, stopImpersonation } = useAuth();
@@ -44,6 +45,11 @@ export const AccountDropdown: React.FC = () => {
             label: 'Documents',
             icon: <DocumentTextIcon />,
             to: getRoute(['app', 'files']),
+          },
+          {
+            label: 'Widgets',
+            icon: <ChartBarSquareIcon />,
+            to: getRoute(['app', 'intelligence']),
           },
           {
             label: 'Divider',

--- a/src/sections/topNavBar/AccountDropdown.tsx
+++ b/src/sections/topNavBar/AccountDropdown.tsx
@@ -1,10 +1,3 @@
-import {
-  ArrowRightCircleIcon,
-  DocumentTextIcon,
-  PuzzlePieceIcon,
-  UserIcon,
-} from '@heroicons/react/24/solid';
-
 import { Dropdown } from '@/components/Dropdown';
 import { Hexagon } from '@/components/Hexagon';
 import { useGetCollaborators } from '@/hooks/collaborators';
@@ -13,7 +6,13 @@ import { useMy } from '@/hooks/useMy';
 import Avatar from '@/sections/topNavBar/Avatar';
 import { useAuth } from '@/state/auth';
 import { getRoute } from '@/utils/route.util';
-import { ChartBarSquareIcon } from '@heroicons/react/24/outline';
+import {
+  ChartBarSquareIcon,
+  DocumentTextIcon,
+  PuzzlePieceIcon,
+  UserIcon,
+  ArrowRightCircleIcon,
+} from '@heroicons/react/24/outline';
 
 export const AccountDropdown: React.FC = () => {
   const { friend, me, startImpersonation, stopImpersonation } = useAuth();

--- a/src/sections/topNavBar/Avatar.tsx
+++ b/src/sections/topNavBar/Avatar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { UserIcon } from '@heroicons/react/24/solid';
+import { UserIcon } from '@heroicons/react/24/outline';
 
 import { useGetProfilePictureUrl } from '@/hooks/profilePicture';
 

--- a/src/sections/topNavBar/TopNavBar.tsx
+++ b/src/sections/topNavBar/TopNavBar.tsx
@@ -56,9 +56,6 @@ export function TopNavBar() {
               ],
             }}
           />
-          <Link to={getRoute(['app', 'intelligence'])} className="ml-4 text-sm">
-            Intelligence
-          </Link>
           <div className="ml-auto flex items-center md:hidden">
             <Notifications />
             <AccountDropdown />

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,7 @@ export const DisplaySeverities: Record<string, string> = {
 };
 
 export const SeedLabels: Record<string, string> = {
-  cloud: 'Cloud Accounts',
+  cloud: 'Integrations',
   ipv4: 'IPv4 Addresses',
   cidr: 'CIDR Ranges',
   repository: 'GitHub Organizations',


### PR DESCRIPTION
### Summary

- Moves intelligence tab under account menu
- Rename Seed filter label as "Integrations"

### Type

Nit 

### Context

<img width="1604" alt="image" src="https://github.com/praetorian-inc/chariot-ui/assets/19853007/e2296b3f-a076-4414-98f9-2b4fd59c0d50">
