### PR TITLE
Fix for filter menu

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -80,8 +80,11 @@ export const Menu: React.FC<MenuProps> = props => {
                   } else {
                     newSelected = [...prev, item.value];
                   }
-                  // Remove empty string if there are other values for multiSelect 'All' option
-                  newSelected = newSelected.filter(v => v !== '');
+                  // Toggle "All option" and other values
+                  newSelected =
+                    newSelected.length > 0
+                      ? newSelected.filter(v => v !== '')
+                      : [''];
                 } else {
                   // If 'All' option is selected, remove all other values
                   newSelected = [''];

--- a/src/components/ui/RiskDropdown.tsx
+++ b/src/components/ui/RiskDropdown.tsx
@@ -115,7 +115,7 @@ export const RiskDropdown: React.FC<Props> = ({
     `${risk.status?.[0]}${risk.status?.[2] || ''}` as RiskStatus;
   const riskSeverityKey = risk.status?.[1] as RiskSeverity;
 
-  const statusLabel = RiskStatusLabel[riskStatusKey] || 'Unknown'; // Unknown is added to handle the old statuses
+  const statusLabel = RiskStatusLabel[riskStatusKey] || 'Closed'; // Closed is added to handle the old statuses
   const severityLabel = SeverityDef[riskSeverityKey];
 
   function handleStatusChange(value: RiskCombinedStatus) {

--- a/src/components/ui/RiskDropdown.tsx
+++ b/src/components/ui/RiskDropdown.tsx
@@ -115,7 +115,7 @@ export const RiskDropdown: React.FC<Props> = ({
     `${risk.status?.[0]}${risk.status?.[2] || ''}` as RiskStatus;
   const riskSeverityKey = risk.status?.[1] as RiskSeverity;
 
-  const statusLabel = RiskStatusLabel[riskStatusKey];
+  const statusLabel = RiskStatusLabel[riskStatusKey] || 'Unknown'; // Unknown is added to handle the old statuses
   const severityLabel = SeverityDef[riskSeverityKey];
 
   function handleStatusChange(value: RiskCombinedStatus) {


### PR DESCRIPTION
### Summary

- When filter "Open" is selected and then toggled as deselected, there is nothing selected in the filter, so for that case, we can select back "All"
- For old statuses, which do not map to anything today in the UI, adding an "Unknown" state

### Type

Specify if this is a bug fix, new feature, breaking change, or documentation update.

### Context

**Before**
<img width="403" alt="image" src="https://github.com/praetorian-inc/chariot-ui/assets/19853007/32f869d8-358d-4297-be25-953ef778f20e">

<img width="237" alt="image" src="https://github.com/praetorian-inc/chariot-ui/assets/19853007/ce5d24fb-ec7d-4cd8-a262-1626d291cdfb">


**After**
<img width="335" alt="image" src="https://github.com/praetorian-inc/chariot-ui/assets/19853007/b097c64f-d9a5-4739-9fcc-a4bbc5020f86">

<img width="251" alt="image" src="https://github.com/praetorian-inc/chariot-ui/assets/19853007/9367d079-f8ad-4ec1-89c0-11f3f55590c4">

