### PR TITLE
Allow multiple GCP and Azure integrations

### DIFF
--- a/src/utils/availableIntegrations.tsx
+++ b/src/utils/availableIntegrations.tsx
@@ -313,6 +313,7 @@ export const IntegrationsMeta: IntegrationMeta[] = [
     logo: '/icons/GoogleCloud.svg',
     connected: true,
     types: [IntegrationType.AssetDiscovery],
+    multiple: true,
     inputs: [
       {
         name: 'username',
@@ -357,6 +358,7 @@ export const IntegrationsMeta: IntegrationMeta[] = [
     logo: '/icons/Azure.svg',
     connected: true,
     types: [IntegrationType.AssetDiscovery],
+    multiple: true,
     inputs: [
       {
         name: 'username',


### PR DESCRIPTION
### Summary

Allows the creation of multiple GCP and Azure integrations. We currently support this on the backend and the CLI.

### Type

New Feature
