### PR TITLE
Enable multiple github and gitlab integrations

### DIFF
--- a/src/utils/availableIntegrations.tsx
+++ b/src/utils/availableIntegrations.tsx
@@ -214,6 +214,7 @@ export const IntegrationsMeta: IntegrationMeta[] = [
       "Discover your GitHub organization's repositories and identify risks",
     logo: '/icons/GitHub.svg',
     connected: true,
+    multiple: true,
     types: [IntegrationType.AssetDiscovery, IntegrationType.RiskIdentification],
     inputs: [
       {
@@ -436,6 +437,7 @@ export const IntegrationsMeta: IntegrationMeta[] = [
       "Discover your GitLab organization's repositories and identify risks",
     logo: '/icons/GitLab.svg',
     connected: true,
+    multiple: true,
     types: [IntegrationType.AssetDiscovery, IntegrationType.RiskIdentification],
     inputs: [
       {


### PR DESCRIPTION
### Summary

Enable multiple github and gitlab integrations. This is supported on the backend already. This is intended to assist with our #1 week goal this week by reducing the restricitions around these integrations.

### Type

New Feature
