### PR TITLE
Order of priority of integration value object fixed

### DIFF
--- a/src/sections/add/AddAsset.tsx
+++ b/src/sections/add/AddAsset.tsx
@@ -44,7 +44,7 @@ const AddAssetMessage = () => (
       </p>
       <p className="mt-0 rounded-sm bg-layer1 p-4 text-sm text-gray-500">
         For example, at Acme Corporation, an asset could be:
-        <ul className="my-0 marker:text-gray-300 list-disc pl-5 text-sm ">
+        <ul className="my-0 list-disc pl-5 text-sm marker:text-gray-300 ">
           <li>
             Domains: <span className="font-semibold">acme.com</span>
           </li>
@@ -343,15 +343,15 @@ export const TabPanelContent = (props: TabPanelContentProps) => {
                       ...input,
                       value: String(
                         input.value ||
-                          connectedIntegration[index]?.[
-                            input.name as keyof LinkAccount
-                          ] ||
                           (
                             connectedIntegration[index]?.config as Record<
                               string,
                               string
                             >
                           )?.[input.name] ||
+                          connectedIntegration[index]?.[
+                            input.name as keyof LinkAccount
+                          ] ||
                           ''
                       ),
                     }))}


### PR DESCRIPTION
### Summary

Order of priority of integration value object fixed
Fix #226 

### Type

Bug fix

### Context

UI was checking the `name` field from the main object first.
Instead we need to check the `config` first

<img width="733" alt="Screenshot 2024-07-09 at 1 03 35 PM" src="https://github.com/praetorian-inc/chariot-ui/assets/19853007/092c96c5-1bd8-4c2f-9ef3-d416e4535b35">

