### PR TITLE
Table column resize

### DIFF
--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -23,6 +23,7 @@ import { Tooltip } from '@/components/Tooltip';
 import { Body } from '@/components/ui/Body';
 import { NoData } from '@/components/ui/NoData';
 import { useScroll } from '@/hooks';
+import { useResize } from '@/hooks/useResize';
 import {
   RenderHeaderBreadcrumbSection,
   RenderHeaderExtraContentSection,
@@ -53,6 +54,7 @@ export function Table<TData>(props: TableProps<TData>) {
     isTableView = true,
     primaryAction,
     skipHeader,
+    resize = false,
   } = props;
 
   const [expandedGroups, setExpandedGroups] = useState(
@@ -393,6 +395,7 @@ export function Table<TData>(props: TableProps<TData>) {
                         : column.fixedWidth
                     }
                     align={column.align}
+                    resize={resize}
                   >
                     {column.label}
                   </Th>
@@ -456,8 +459,14 @@ export function Th(props: {
   fixedWidth?: number;
   children: ReactNode;
   align?: CellAlignment;
+  resize?: boolean;
 }) {
-  const { fixedWidth, ...restProps } = props;
+  const ref = useRef<HTMLTableCellElement>(null);
+  const { fixedWidth, resize = false, ...restProps } = props;
+  const { size, onMouseDown } = useResize({
+    el: ref.current || document.createElement('div'),
+    minWidth: fixedWidth || 100,
+  });
 
   return (
     <th
@@ -468,15 +477,32 @@ export function Th(props: {
         props.align === 'right' && 'text-right',
         props.className
       )}
-      style={{
-        ...(fixedWidth
-          ? { maxWidth: fixedWidth, minWidth: fixedWidth, width: fixedWidth }
-          : {}),
-      }}
+      style={
+        resize
+          ? {
+              minWidth: fixedWidth || 100,
+              width: size.x || fixedWidth,
+            }
+          : fixedWidth
+            ? { maxWidth: fixedWidth, minWidth: fixedWidth, width: fixedWidth }
+            : {}
+      }
+      ref={ref}
     >
       <div className="th-top-border absolute left-0 top-0 w-full border-b border-solid border-default" />
       <div className="th-bottom-border absolute bottom-0 left-0 w-full border-b border-solid border-default" />
-      {props.children}
+
+      <div className="flex justify-between">
+        {props.children}
+        {resize && (
+          <span
+            className="resize-el text-layer1 hover:cursor-col-resize"
+            onMouseDown={onMouseDown}
+          >
+            |
+          </span>
+        )}
+      </div>
     </th>
   );
 }

--- a/src/components/table/types.ts
+++ b/src/components/table/types.ts
@@ -34,6 +34,7 @@ export interface TableProps<TData> {
     filter: (data: TData) => boolean;
   }[];
   skipHeader?: boolean;
+  resize?: boolean;
 }
 
 export interface Column<TData> {

--- a/src/hooks/useResize.ts
+++ b/src/hooks/useResize.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+interface Props {
+  el: HTMLElement;
+  minWidth?: number;
+}
+
+export const useResize = (props: Props) => {
+  const { minWidth = 100, el } = props;
+  const [size, setSize] = useState({
+    x: 0,
+    y: 0,
+  });
+
+  useEffect(() => {
+    const { width, height } = el.getBoundingClientRect();
+    setSize({
+      x: getWidth(width),
+      y: height,
+    });
+  }, [el]);
+
+  const getWidth = (width: number) => {
+    return width < minWidth ? minWidth : width;
+  };
+
+  const onMouseDown = (mouseDownEvent: React.MouseEvent<HTMLDivElement>) => {
+    const startSize = size;
+    const startPosition = { x: mouseDownEvent.pageX, y: mouseDownEvent.pageY };
+    document.body.classList.add('col-resize');
+
+    function onMouseMove(mouseMoveEvent: MouseEvent) {
+      setSize(() => ({
+        x: getWidth(startSize.x - startPosition.x + mouseMoveEvent.pageX),
+        y: startSize.y - startPosition.y + mouseMoveEvent.pageY,
+      }));
+    }
+
+    function onMouseUp() {
+      document.body.classList.remove('col-resize');
+      document.body.removeEventListener('mousemove', onMouseMove);
+    }
+
+    // Attach mousemove and mouseup event listeners to the body only after mousedown event
+    document.body.addEventListener('mousemove', onMouseMove);
+    document.body.addEventListener('mouseup', onMouseUp, { once: true });
+  };
+
+  return {
+    size,
+    onMouseDown,
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,10 @@
   color: #fff;
 }
 
+.col-resize {
+  cursor: col-resize;
+}
+
 .markdownSelection textarea::selection {
   background-color: #7f67d75f;
   color: #fff;

--- a/src/sections/Assets.tsx
+++ b/src/sections/Assets.tsx
@@ -1,16 +1,13 @@
 import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronDownIcon } from '@heroicons/react/20/solid';
-import {
-  PauseIcon,
-  PlusIcon,
-  QuestionMarkCircleIcon,
-} from '@heroicons/react/24/outline';
+import { PauseIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { CheckIcon, XMarkIcon } from '@heroicons/react/24/solid';
 
 import { Chip } from '@/components/Chip';
 import { Dropdown } from '@/components/Dropdown';
 import { AssetsIcon, RisksIcon } from '@/components/icons';
+import { getAssetStatusIcon } from '@/components/icons/AssetStatus.icon';
 import { SpinnerIcon } from '@/components/icons/Spinner.icon';
 import { Link } from '@/components/Link';
 import { OverflowText } from '@/components/OverflowText';
@@ -35,7 +32,6 @@ import {
 import { useMergeStatus } from '@/utils/api';
 import { getRoute } from '@/utils/route.util';
 import { StorageKey } from '@/utils/storage/useStorage.util';
-import { getAssetStatusIcon } from '@/components/icons/AssetStatus.icon';
 
 type Severity = 'I' | 'L' | 'M' | 'H' | 'C';
 type SeverityOpenCounts = Partial<Record<Severity, Risk[]>>;
@@ -151,7 +147,6 @@ const Assets: React.FC = () => {
         return (
           <div className="flex gap-2">
             <span>{asset.name}</span>
-            {/* {asset.seed && <Chip>Seed</Chip>} */}
             {integration && <Chip>Integration</Chip>}
           </div>
         );
@@ -311,6 +306,7 @@ const Assets: React.FC = () => {
             }}
           />
         }
+        resize={true}
         selection={{}}
         primaryAction={() => {
           return {
@@ -378,7 +374,7 @@ const Assets: React.FC = () => {
                   label: (
                     <span>
                       Freeze
-                      <span className="text-xs text-gray-600 bg-layer1 p-2 ml-2 rounded-md">
+                      <span className="ml-2 rounded-md bg-layer1 p-2 text-xs text-gray-600">
                         Unknown Asset
                       </span>
                     </span>

--- a/src/sections/Files.tsx
+++ b/src/sections/Files.tsx
@@ -195,6 +195,7 @@ const Files: React.FC = () => {
       <Table
         columns={columns}
         data={filteredAndSortedFiles}
+        resize={true}
         error={error}
         status={status}
         fetchNextPage={fetchNextPage}

--- a/src/sections/Jobs.tsx
+++ b/src/sections/Jobs.tsx
@@ -160,6 +160,7 @@ const Jobs: React.FC = () => {
   return (
     <div className="flex w-full flex-col">
       <Table
+        resize={true}
         filters={
           <Dropdown
             styleType="header"

--- a/src/sections/RisksTable.tsx
+++ b/src/sections/RisksTable.tsx
@@ -360,6 +360,7 @@ export function Risks() {
     <div className="flex w-full flex-col">
       <Table
         name={'risks'}
+        resize={true}
         filters={
           <div className="flex gap-4">
             <Dropdown


### PR DESCRIPTION
### Summary

Adds a `resize` prop to resize the table component.
It saves your previous width to local storage and recovers it on refresh / page change.
TODO :
- The width can go beyond the table width at the moment and then the row becomes scrollable. Need to check on that

### Type

New feature

### Context

https://github.com/praetorian-inc/chariot-ui/assets/19853007/8e8d8a97-510e-4a02-a9f2-16ae3555bec0

