### PR TITLE
Prevent integration creation unless required fields are populated

### DIFF
--- a/src/sections/add/AddAsset.tsx
+++ b/src/sections/add/AddAsset.tsx
@@ -195,7 +195,7 @@ export function AddAsset() {
       footer={{
         isLoading: creatingAsset === 'pending',
         text: selectedIntegration.length ? 'Update' : 'Add',
-        onClick: handleAddAsset,
+        form: 'new-asset',
         disconnect: selectedIntegration.length
           ? {
               text: 'Disconnect',
@@ -246,6 +246,7 @@ export function AddAsset() {
                 onChange={setFormData}
                 tab={tab}
                 onCancel={onClose}
+                onSubmit={handleAddAsset}
               />
             );
           })}
@@ -260,10 +261,11 @@ interface TabPanelContentProps {
   tab: IntegrationMeta;
   connectedIntegration: Account[];
   onCancel: () => void;
+  onSubmit: () => void;
 }
 
 export const TabPanelContent = (props: TabPanelContentProps) => {
-  const { tab, onChange, connectedIntegration, onCancel } = props;
+  const { tab, onChange, connectedIntegration, onCancel, onSubmit } = props;
   const {
     description = '',
     markup = '',
@@ -337,6 +339,10 @@ export const TabPanelContent = (props: TabPanelContentProps) => {
         <form
           id="new-asset"
           className="border-1 w-full rounded-sm border border-gray-200 p-4"
+          onSubmit={event => {
+            event.preventDefault();
+            onSubmit();
+          }}
         >
           {message && <div className="mb-4 text-gray-500">{message}</div>}
           <div>

--- a/src/sections/add/AddRisks.tsx
+++ b/src/sections/add/AddRisks.tsx
@@ -151,6 +151,9 @@ export const AddRisks = () => {
   }, [selectedIndex]);
 
   async function handleConfigureIntegration() {
+    if (selectedIndex === 0) {
+      return;
+    }
     integrationFormData.map(data => link(data as unknown as LinkAccount));
     onClose();
   }
@@ -181,10 +184,8 @@ export const AddRisks = () => {
         size="lg"
         closeOnOutsideClick={false}
         footer={{
-          onClick:
-            selectedIndex === 0 ? () => null : handleConfigureIntegration,
           text: selectedIndex === 0 ? 'Add' : 'Configure',
-          form: selectedIndex === 0 ? 'addRisk' : undefined,
+          form: selectedIndex === 0 ? 'addRisk' : 'new-asset',
           disconnect: selectedIntegration.length
             ? {
                 text: 'Disconnect',
@@ -324,6 +325,7 @@ export const AddRisks = () => {
                   onChange={setIntegrationFormData}
                   tab={tab}
                   onCancel={onClose}
+                  onSubmit={handleConfigureIntegration}
                 />
               );
             })}

--- a/src/sections/add/AddRisks.tsx
+++ b/src/sections/add/AddRisks.tsx
@@ -151,9 +151,6 @@ export const AddRisks = () => {
   }, [selectedIndex]);
 
   async function handleConfigureIntegration() {
-    if (selectedIndex === 0) {
-      return;
-    }
     integrationFormData.map(data => link(data as unknown as LinkAccount));
     onClose();
   }


### PR DESCRIPTION
### Summary
Addresses: https://github.com/praetorian-inc/chariot-ui/issues/341

Prevent form submission and subsequent integration creation unless input fields marked as `required` are populated.

### Type

Bug fix
