### PR TITLE
correct webhook example

### DIFF
--- a/src/components/ui/WebhookExample.tsx
+++ b/src/components/ui/WebhookExample.tsx
@@ -35,7 +35,8 @@ const WebhookExample: React.FC<Props> = ({ defaultPin }) => {
       payload: `{  
   "dns": "public-facing-api.domain.com",
   "name": "192.168.15.30",
-  "finding": "exposed-administration-interface"
+  "finding": "exposed-administration-interface",
+  "source": "webhook" # optional source of the risk, like 'nessus' or 'qualys'
 }`,
     },
   ];

--- a/src/sections/overview/Module.tsx
+++ b/src/sections/overview/Module.tsx
@@ -200,16 +200,6 @@ export const Integrations: Record<Integration, IntegrationMeta> = {
         name: 'pin',
         hidden: true,
       },
-      {
-        label: 'Source',
-        value: '',
-        placeholder: 'internal',
-        name: 'source',
-        required: false,
-        info: {
-          text: 'Adds an optional source attribute to the message',
-        },
-      },
     ],
     markup: <WebhookExample defaultPin={defaultPin} />,
   },


### PR DESCRIPTION
### Summary

Correct the webhook module to indicate that source is an optional POST parameter for risks.

### Type

Bug Fix
