### PR TITLE
Add forceRefresh auth token before expiry

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -417,7 +417,7 @@ export interface AuthState {
   clientId: string;
   me: string;
   rToken?: string;
-  expiry?: Date;
+  expiry?: number;
   friend: { email: string; displayName: string };
   isImpersonating: boolean;
   userPoolId: string;


### PR DESCRIPTION
### Summary

- Add forceRefresh auth token before expiry
- Currently Amplify is not refreshing the auth token automatically, as mentioned in [doc](https://docs.amplify.aws/react/build-a-backend/auth/connect-your-frontend/manage-user-sessions/#refreshing-sessions). So added a logic to check the expiry every time switches back to the original tab and forceRefresh the token 5min before expiry 

### Type

Bug fix

### Context

Add any additional details or screenshots.
