### PR TITLE
Updates Scan now

### DIFF
--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -1,8 +1,17 @@
+// eslint-disable-next-line no-restricted-imports
+import { useQueries } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { useAxios } from '@/hooks/useAxios';
 import { useMy } from '@/hooks/useMy';
-import { useMutation } from '@/utils/api';
+import { getQueryKey } from '@/hooks/useQueryKeys';
+import { Job } from '@/types';
+import {
+  mergeJobStatus,
+  mergeStatus,
+  UseExtendQueryOptions,
+  useMutation,
+} from '@/utils/api';
 
 export function useReRunJob() {
   const axios = useAxios();
@@ -47,12 +56,14 @@ export function useBulkReRunJob() {
 
   return useMutation({
     defaultErrorMessage: 'Failed to re run job',
-    mutationFn: async (jobs: { capability: string; dns: string }[]) => {
+    mutationFn: async (
+      jobs: { capability: string; dns?: string; jobKey?: string }[]
+    ) => {
       const promises = jobs
-        .map(async ({ capability, dns }) => {
+        .map(async ({ capability, dns, jobKey }) => {
           const { data } = await axios.post(`/job/`, {
             name: capability,
-            key: `#asset#${dns}`,
+            key: jobKey || `#asset#${dns}`,
           });
 
           return data;
@@ -75,3 +86,39 @@ export function useBulkReRunJob() {
     },
   });
 }
+
+export const useJobsStatus = (
+  jobKeys: string[],
+  options?: UseExtendQueryOptions<Job>
+) => {
+  const axios = useAxios();
+  return useQueries({
+    queries: jobKeys
+      .filter(x => Boolean(x))
+      .map(key => {
+        console.log({ options });
+        return {
+          ...options,
+          staleTime: Infinity,
+          queryKey: getQueryKey.getMy('job', key),
+          queryFn: async () => {
+            const res = await axios.get(`/my`, {
+              params: {
+                key: `#job#${key}`,
+              },
+            });
+
+            return res.data.jobs[0] as Job;
+          },
+        };
+      }),
+    combine: results => {
+      return {
+        data: mergeJobStatus(
+          results.map(result => result.data?.status || '') || []
+        ),
+        status: mergeStatus(...results.map(result => result.status)),
+      };
+    },
+  });
+};

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -96,10 +96,8 @@ export const useJobsStatus = (
     queries: jobKeys
       .filter(x => Boolean(x))
       .map(key => {
-        console.log({ options });
         return {
           ...options,
-          staleTime: Infinity,
           queryKey: getQueryKey.getMy('job', key),
           queryFn: async () => {
             const res = await axios.get(`/my`, {

--- a/src/sections/detailsDrawer/RiskDrawer.tsx
+++ b/src/sections/detailsDrawer/RiskDrawer.tsx
@@ -145,7 +145,11 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
   const jobKeys = useMemo(
     () =>
       (attributesGenericSearch?.attributes || [])
-        .filter(({ name }) => name === 'source')
+        .filter(
+          ({ name, value }) =>
+            name === 'source' &&
+            (value.startsWith('#attribute') || value.startsWith('#asset'))
+        )
         .map(attribute => attribute.value),
     [attributesGenericSearch]
   );
@@ -314,17 +318,22 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
               <Tooltip
                 placement="top"
                 title={
-                  risk.source && !isManualORPRrovidedRisk(risk)
-                    ? isJobRunningForThisRisk
-                      ? 'Scanning in progress'
-                      : 'Revalidate the risk'
-                    : 'On-demand scanning is only available for automated risk discovery.'
+                  isInitialLoading
+                    ? ''
+                    : risk.source && !isManualORPRrovidedRisk(risk)
+                      ? isJobRunningForThisRisk
+                        ? 'Scanning in progress'
+                        : jobKeys.length === 0
+                          ? 'On-demand scanning is only available for risk which have a source attribute'
+                          : 'Revalidate the risk'
+                      : 'On-demand scanning is only available for automated risk discovery.'
                 }
               >
                 <Button
                   className="border-1 h-8 border border-default"
                   startIcon={<ArrowPathIcon className="size-5" />}
                   disabled={
+                    isInitialLoading ||
                     jobKeys.length === 0 ||
                     isManualORPRrovidedRisk(risk) ||
                     Boolean(isJobRunningForThisRisk)

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -18,6 +18,7 @@ export type { QueryStatus } from '@tanstack/react-query';
 export { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { queryClient } from '@/queryclient';
+import { JobStatus } from '@/types';
 import { createError } from '@/utils/error.util';
 import { capitalize } from '@/utils/lodash.util';
 import { appendPeriodIfMissing } from '@/utils/text.util';
@@ -172,6 +173,23 @@ function appendContactSupport(error: string) {
 interface CustomOptions {
   defaultErrorMessage: string;
   errorByStatusCode?: Record<number, string>;
+}
+
+type JobStatusType = JobStatus | '';
+export function mergeJobStatus(jobStatus: JobStatusType[]): JobStatusType {
+  if (jobStatus.includes(JobStatus.Queued)) {
+    return JobStatus.Queued;
+  }
+  if (jobStatus.includes(JobStatus.Running)) {
+    return JobStatus.Running;
+  }
+  if (jobStatus.includes(JobStatus.Fail)) {
+    return JobStatus.Fail;
+  }
+  if (jobStatus.includes(JobStatus.Pass)) {
+    return JobStatus.Pass;
+  }
+  return '';
 }
 
 /**


### PR DESCRIPTION
### Summary

This PR :
- Updates the "Scan Now" button functionality to trigger all the jobs for `name:source` attributes
- This also add a hook `useJobsStatus` that can use useQueries to fetch job status for multiple jobs. 

### Type

Bug fix

### Context

Add any additional details or screenshots.
