### PR TITLE
fix job key for bas module

### DIFF
--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -52,7 +52,7 @@ export function useBulkReRunJob() {
         .map(async ({ capability, dns }) => {
           const { data } = await axios.post(`/job/`, {
             name: capability,
-            key: `#asset#${dns}`,
+            key: `#job#${dns}#${dns}#${capability}`,
           });
 
           return data;


### PR DESCRIPTION
updating the key sent to the /job backend to match the expected regex for the bas module