### PR TITLE
Risk drawer timeline: Takes all jobs for that source into consideration

### DIFF
--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -175,8 +175,9 @@ interface CustomOptions {
   errorByStatusCode?: Record<number, string>;
 }
 
-type JobStatusType = JobStatus | '';
-export function mergeJobStatus(jobStatus: JobStatusType[]): JobStatusType {
+export function mergeJobStatus(
+  jobStatus: (JobStatus | undefined)[]
+): JobStatus | undefined {
   if (jobStatus.includes(JobStatus.Queued)) {
     return JobStatus.Queued;
   }
@@ -189,7 +190,7 @@ export function mergeJobStatus(jobStatus: JobStatusType[]): JobStatusType {
   if (jobStatus.includes(JobStatus.Pass)) {
     return JobStatus.Pass;
   }
-  return '';
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
### Summary

- Risk drawer timeline: Takes all jobs for that source into consideration
   - Instead of mapping the job response keys, it directly takes all the `#job#dns` response into account and checks for all the jobs with same risk source. 

### Type

Specify if this is a bug fix, new feature, breaking change, or documentation update.

### Context

Add any additional details or screenshots.
