### PR TITLE
Fix/scan now 2

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -113,7 +113,7 @@ export function Drawer({
                 ref={ref}
               >
                 <div className="h-full overflow-auto text-default">
-                  <div className="mb-2 flex items-center justify-between px-10 pb-4">
+                  <div className="my-2 flex items-center justify-between px-10 pb-4">
                     <div className="flex w-full items-center">
                       <Tooltip title="Go Back">
                         <ChevronLeftIcon

--- a/src/sections/Jobs.tsx
+++ b/src/sections/Jobs.tsx
@@ -35,7 +35,7 @@ export const getStatusColor = (status: JobStatus) => {
   }
 };
 
-const getStatusText = (status: JobStatus) => {
+export const getStatusText = (status: JobStatus) => {
   const classes = 'px-1 text-xs leading-5 font-medium rounded-full text-center';
   switch (status) {
     case JobStatus.Pass:

--- a/src/sections/detailsDrawer/RiskDrawer.tsx
+++ b/src/sections/detailsDrawer/RiskDrawer.tsx
@@ -30,6 +30,7 @@ import { useGetFile, useUploadFile } from '@/hooks/useFiles';
 import { useGenericSearch } from '@/hooks/useGenericSearch';
 import { useBulkReRunJob, useJobsStatus } from '@/hooks/useJobs';
 import { useReportRisk, useUpdateRisk } from '@/hooks/useRisks';
+import { AddAttribute } from '@/sections/detailsDrawer/AddAttribute';
 import { Comment } from '@/sections/detailsDrawer/Comment';
 import { getDrawerLink } from '@/sections/detailsDrawer/getDrawerLink';
 import { getStatusColor, getStatusText } from '@/sections/Jobs';
@@ -152,6 +153,12 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
   const jobsStatus = mergeJobStatus(
     Object.values(jobsData).map(job => job?.status)
   );
+
+  const lastScan =
+    Object.values(jobsData)
+      .map(job => job?.updated)
+      .sort()
+      .reverse()[0] || '';
 
   // const jobsTimeline = useMemo(() => {
   //   return getJobTimeline({
@@ -418,13 +425,11 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
                   <h3 className="text-2xl font-semibold tracking-wide text-gray-900">
                     Attributes
                   </h3>
-                  {jobsStatus && (
-                    <div
-                      className={`flex items-center rounded-md px-4 py-1 ${getStatusColor(jobsStatus)}`}
-                    >
-                      {getStatusText(jobsStatus)}
-                    </div>
-                  )}
+                  <AddAttribute className="ml-auto" resourceKey={risk.key} />
+                  <JobStatusBadge
+                    status={jobsStatus}
+                    lastScan={formatDate(lastScan)}
+                  />
                 </div>
 
                 <div className="space-y-4">
@@ -500,7 +505,7 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
                                               JobStatus.Pass,
                                               JobStatus.Fail,
                                             ].includes(status) &&
-                                            'animate-spin cursor-disabled'
+                                            'animate-spin cursor-not-allowed'
                                         )}
                                         onClick={async () => {
                                           const [response] =
@@ -679,6 +684,33 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
     </Drawer>
   );
 }
+
+const JobStatusBadge = ({
+  status,
+  lastScan,
+}: {
+  status?: JobStatus;
+  lastScan: string;
+}) => {
+  if (!status) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`!ml-auto flex min-w-40 items-center justify-center rounded-md px-4 py-1 text-xs ${getStatusColor(status)}`}
+    >
+      {status === JobStatus.Pass && <span>{`Last Scan: ${lastScan}`}</span>}
+      {status === JobStatus.Fail && <span>{`Failed: ${lastScan})`}</span>}
+      {status === JobStatus.Running && (
+        <span className="flex gap-2">
+          Scanning <ArrowPathIcon className="size-4 animate-spin" />
+        </span>
+      )}
+      {status === JobStatus.Queued && <span>Queued</span>}
+    </div>
+  );
+};
 
 function getHistoryDiff(
   history: EntityHistory,

--- a/src/sections/detailsDrawer/RiskDrawer.tsx
+++ b/src/sections/detailsDrawer/RiskDrawer.tsx
@@ -14,7 +14,6 @@ import {
 
 import { Button } from '@/components/Button';
 import { Drawer } from '@/components/Drawer';
-import { HorizontalTimeline } from '@/components/HorizontalTimeline';
 import { RisksIcon } from '@/components/icons';
 import { getRiskSeverityIcon } from '@/components/icons/RiskSeverity.icon';
 import { UnionIcon } from '@/components/icons/Union.icon';
@@ -29,15 +28,11 @@ import { useMy } from '@/hooks';
 import { useGetKev } from '@/hooks/kev';
 import { useGetFile, useUploadFile } from '@/hooks/useFiles';
 import { useGenericSearch } from '@/hooks/useGenericSearch';
-import {
-  getJobTimeline,
-  useBulkReRunJob,
-  useJobsStatus,
-} from '@/hooks/useJobs';
+import { useBulkReRunJob, useJobsStatus } from '@/hooks/useJobs';
 import { useReportRisk, useUpdateRisk } from '@/hooks/useRisks';
 import { Comment } from '@/sections/detailsDrawer/Comment';
 import { getDrawerLink } from '@/sections/detailsDrawer/getDrawerLink';
-import { getStatusText } from '@/sections/Jobs';
+import { getStatusColor, getStatusText } from '@/sections/Jobs';
 import {
   Attribute,
   EntityHistory,
@@ -158,16 +153,16 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
     Object.values(jobsData).map(job => job?.status)
   );
 
-  const jobsTimeline = useMemo(() => {
-    return getJobTimeline({
-      status: jobsStatus,
-      updated:
-        Object.values(jobsData)
-          .map(job => job?.updated)
-          .sort()
-          .reverse()[0] || '',
-    });
-  }, [jobsStatus, jobsData]);
+  // const jobsTimeline = useMemo(() => {
+  //   return getJobTimeline({
+  //     status: jobsStatus,
+  //     updated:
+  //       Object.values(jobsData)
+  //         .map(job => job?.updated)
+  //         .sort()
+  //         .reverse()[0] || '',
+  //   });
+  // }, [jobsStatus, jobsData]);
 
   const isJobsRunning =
     jobsStatus === JobStatus.Running || jobsStatus === JobStatus.Queued;
@@ -213,20 +208,6 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
         'w-full rounded-t-lg bg-zinc-100 pb-0 shadow-lg',
         severityClass
       )}
-      header={
-        isInitialLoading ? null : (
-          <div className="flex w-full flex-col px-10 pb-0 pt-6">
-            {/* Job Timeline and Actions */}
-            <HorizontalTimeline
-              steps={jobsTimeline}
-              current={jobsTimeline.findIndex(
-                ({ status }) => status === jobsStatus
-              )}
-              className={severityClass + ' brightness-90'}
-            />
-          </div>
-        )
-      }
     >
       <Loader isLoading={isInitialLoading} type="spinner">
         <div className="flex h-full flex-col gap-2 px-8 pt-0">
@@ -437,6 +418,13 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
                   <h3 className="text-2xl font-semibold tracking-wide text-gray-900">
                     Attributes
                   </h3>
+                  {jobsStatus && (
+                    <div
+                      className={`flex items-center rounded-md px-4 py-1 ${getStatusColor(jobsStatus)}`}
+                    >
+                      {getStatusText(jobsStatus)}
+                    </div>
+                  )}
                 </div>
 
                 <div className="space-y-4">

--- a/src/sections/detailsDrawer/RiskDrawer.tsx
+++ b/src/sections/detailsDrawer/RiskDrawer.tsx
@@ -160,17 +160,6 @@ export function RiskDrawer({ compositeKey, open }: RiskDrawerProps) {
       .sort()
       .reverse()[0] || '';
 
-  // const jobsTimeline = useMemo(() => {
-  //   return getJobTimeline({
-  //     status: jobsStatus,
-  //     updated:
-  //       Object.values(jobsData)
-  //         .map(job => job?.updated)
-  //         .sort()
-  //         .reverse()[0] || '',
-  //   });
-  // }, [jobsStatus, jobsData]);
-
   const isJobsRunning =
     jobsStatus === JobStatus.Running || jobsStatus === JobStatus.Queued;
 

--- a/src/utils/storage/useStorage.util.ts
+++ b/src/utils/storage/useStorage.util.ts
@@ -17,6 +17,7 @@ export enum StorageKey {
   RUNNING_JOBS = 'RUNNING_JOBS',
   ASESET_PRIORITY_FILTER = 'asset-priority',
   RESIZE = 'resizeColumn',
+  RISK_JOB_MAP = 'riskJobMap',
 }
 
 interface UseStorageOptions<S> {


### PR DESCRIPTION
### Summary

- This PR addresses the change to allow "Scan Now" for individual attributes
- Scan Timeline now takes account of /job api response for job key that was triggered 

### Type

Feature update

### Context

<img width="1695" alt="image" src="https://github.com/user-attachments/assets/03744dc2-1723-4e33-b50e-c5f26b98d0d9">
<img width="848" alt="image" src="https://github.com/user-attachments/assets/72f04161-a08f-4519-a30a-df799290cf28">
